### PR TITLE
changed path to karma bin: solve ENOENT error

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -23,7 +23,7 @@
       }
     },
     "jasmine-core": {
-      "version": "2.1.3"
+      "version": "2.2.0"
     },
     "karma": {
       "version": "0.12.31",
@@ -138,14 +138,6 @@
                       "version": "2.0.1"
                     }
                   }
-                }
-              }
-            },
-            "fsevents": {
-              "version": "0.3.5",
-              "dependencies": {
-                "nan": {
-                  "version": "1.5.3"
                 }
               }
             }

--- a/main.js
+++ b/main.js
@@ -107,7 +107,7 @@ KarmaInternals = {
     // TODO: Use sanjo:assets-path-resolver when available
     return path.join(
       KarmaInternals.getAppPath(),
-      '.meteor/local/build/programs/server/npm/sanjo:karma/node_modules/karma/bin/karma'
+      '.meteor/local/build/programs/server/npm/sanjo_karma/node_modules/karma/bin/karma'
     )
   }
 }


### PR DESCRIPTION
I had this error which prevented client unit tests to run:
```
W20141217-10:16:53.161(-5)? (STDERR) events.js:72
W20141217-10:16:53.162(-5)? (STDERR) throw er; // Unhandled 'error' event
W20141217-10:16:53.162(-5)? (STDERR) ^
W20141217-10:16:53.166(-5)? (STDERR) Error: spawn ENOENT
W20141217-10:16:53.167(-5)? (STDERR) at errnoException (child_process.js:1000:11)
W20141217-10:16:53.167(-5)? (STDERR) at Process.ChildProcess._handle.onexit (child_process.js:791:34)
```